### PR TITLE
Use Goboring to build multus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,12 @@ REPO ?= rancher
 image-build-thin: IMAGE = $(REPO)/hardened-multus-cni:$(TAG)
 image-build-thin:
 	docker buildx build \
-		--platform=$(ARCH) \
+		--platform=$(TARGET_PLATFORMS) \
 		--build-arg PKG=$(PKG) \
 		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--target multus-thin \
 		--tag $(IMAGE) \
-		--tag $(IMAGE)-$(ARCH) \
 		--load \
 	.
 
@@ -62,7 +61,6 @@ push-image-thin:
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--target multus-thin \
 		--tag $(IMAGE) \
-		--tag $(IMAGE)-arch \
 		--push \
 		.
 
@@ -71,13 +69,12 @@ image-build-thick: IMAGE = $(REPO)/hardened-multus-thick:$(TAG)
 image-build-thick:
 	docker buildx build \
 		$(IID_FILE_FLAG) \
-		--platform=$(ARCH) \
+		--platform=$(TARGET_PLATFORMS) \
 		--build-arg PKG=$(PKG) \
 		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--target multus-thick \
 		--tag $(IMAGE) \
-		--tag $(IMAGE)-$(ARCH) \
 		--load \
 	.
 
@@ -94,7 +91,6 @@ push-image-thick:
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--target multus-thick \
 		--tag $(IMAGE) \
-		--tag $(IMAGE)-$(ARCH) \
 		--push \
 		.
 


### PR DESCRIPTION
and fix platform arg in Dockerfile

Currently we are producing images with `-arch` suffix like [here]([v4.2.1-build20250627-arch](https://hub.docker.com/layers/rancher/hardened-multus-cni/v4.2.1-build20250627-arch/images/sha256-51007238c679bec881bb6c9f7ae2f8a1b63e7e0e9dbe230cc0b9cc7f32f24ea2)).