### PR TITLE
Switch base image from bci-busybox to bci-nano

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
+ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.25.11b1
 
 
@@ -64,8 +64,20 @@ COPY --from=strip_binary    /cert-approver /
 COPY --from=strip_binary    /install_multus /
 ENTRYPOINT ["/thin_entrypoint"]
 
+# Pull userspace (busybox shell + applets) from k3s-root since bci-nano omits them
+FROM ${GO_IMAGE} AS k3s-root
+ARG TARGETARCH
+ARG K3S_ROOT_VERSION=v0.15.2
+ADD https://github.com/k3s-io/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-${TARGETARCH}.tar /opt/k3s-root/k3s-root.tar
+RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root \
+ && mkdir -p /opt/k3s-root/usr \
+ && mv /opt/k3s-root/bin/aux /opt/k3s-root/usr/sbin \
+ && ln -sf ../bin/busybox /opt/k3s-root/usr/sbin/modprobe \
+ && ln -sf ../bin/busybox /opt/k3s-root/usr/sbin/mount
+
 # Create the thick plugin image
 FROM ${BCI_IMAGE} AS multus-thick
+COPY --from=k3s-root /opt/k3s-root/bin /bin/
 COPY --from=multus-builder  /go/src/github.com/k8snetworkplumbingwg/multus-cni/LICENSE /usr/src/multus-cni/LICENSE
 COPY --from=strip_binary  /multus-daemon /usr/src/multus-cni/bin/multus-daemon
 COPY --from=strip_binary  /multus-shim /usr/src/multus-cni/bin/multus-shim


### PR DESCRIPTION
## What
Switch the runtime base image from `registry.suse.com/bci/bci-busybox` to `registry.suse.com/bci/bci-nano:16.0`, and copy busybox (with its applet symlinks) from [k3s-root](https://github.com/k3s-io/k3s-root) `v0.15.2` into `/bin`.

## Why
`bci-nano` is the most minimal BCI base and has a smaller package/CVE surface, but unlike `bci-busybox` it ships no shell/coreutils. This image's entrypoint relies on `/bin/sh` and busybox applets, so the needed userspace is pulled from k3s-root instead — the same k3s-controlled busybox rke2's other images use. This mirrors the pattern already adopted by [`image-build-kubernetes`](https://github.com/rancher/image-build-kubernetes).

Net effect: SUSE's `bci-busybox` userspace is replaced by k3s-root's busybox on top of the smaller `bci-nano` base, preserving runtime behavior.

## Verification
- `docker build --check`: no warnings; `bci-nano:16.0` resolves/pulls.
- Built a minimal `bci-nano:16.0` + k3s-root `/bin` image and confirmed `/bin/sh` works and all applets used by the entrypoint scripts resolve (`sh`, `cp`, `basename`, `date`, `sed`, `mkdir`, `cat`, `md5sum`, `sha256sum`, `sleep`, `iptables`).

## Notes
- The `Makefile` does not pass `--build-arg BCI_IMAGE`, so the new `ARG` default is what gets used.
- `updatecli` only manages `GO_IMAGE` (build base), not `BCI_IMAGE`, so this won't be auto-reverted.

🤖 Generated with the GitHub Copilot CLI.
